### PR TITLE
Fix: Joined date not displaying correctly on user profile

### DIFF
--- a/backend/models/user.model.js
+++ b/backend/models/user.model.js
@@ -60,7 +60,7 @@ const userSchema = new mongoose.Schema({
 			},
 		],
 },
-{timestaps: true})
+{timestamps: true})
 
 const User = mongoose.model("User", userSchema)
 

--- a/frontend/src/utils/date/index.js
+++ b/frontend/src/utils/date/index.js
@@ -21,7 +21,11 @@ export const formatPostDate = (createdAt) => {
 };
 
 export const formatMemberSinceDate = (createdAt) => {
+	if (!createdAt) return "N/A";
+
 	const date = new Date(createdAt);
+	if (isNaN(date)) return "N/A";
+
 	const months = [
 		"January",
 		"February",
@@ -38,5 +42,6 @@ export const formatMemberSinceDate = (createdAt) => {
 	];
 	const month = months[date.getMonth()];
 	const year = date.getFullYear();
-	return `Joined ${month} ${year}`;
+
+	return `${month} ${year}`; // remove the extra "Joined"
 };


### PR DESCRIPTION
This PR fixes the issue where the joined date on the user's profile page was showing "undefined" or "NaN".

 Fixes:
- Fixed typos in `timestamps: true` in the Mongoose user schema
- Updated `formatJoinedDate` in `frontend/src/utils/date/index.js` to ensure proper formatting and date rendering

Screenshot:
<img width="1117" height="190" alt="image" src="https://github.com/user-attachments/assets/f85f817f-5c54-450f-9034-4e48b571b704" />


This is related to issue #17
Please let me know if further improvements are needed.
