### PR TITLE
Added MIT license section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,7 @@ blabber/
 Built by [Vijaya Mishra](https://github.com/Vijayaa21) 💻  
 Open to contributions, suggestions, and collaboration!
 
+## 📝 License
+
+This project is licensed under the [MIT License](./LICENSE).  
+You are free to use, modify, and distribute this software under the terms of the license.


### PR DESCRIPTION
Title:
🔖 Added MIT License section to README

Description:
This PR addresses issue #27 .
Added a License section in README.md linking to the existing LICENSE file.
Ensures proper attribution and clarity regarding project usage.

GitHub Username: vinitjain2005

Screenshot
<img width="1009" height="205" alt="Screenshot 2025-08-06 214741" src="https://github.com/user-attachments/assets/1b07ada9-8201-45bb-9b57-be8c9831b7dc" />
